### PR TITLE
Get command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0.27", features = ["cargo", "derive"] }
 toml = { version = "0.5.9" }
+sqlx = { version = "0.6", features = [  "runtime-async-std-native-tls", "sqlite" ] }
+async-std = { version = "1", features = [ "attributes" ] } 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 clap = { version = "4.0.27", features = ["cargo", "derive"] }
 toml = { version = "0.5.9" }
 sqlx = { version = "0.6", features = [  "runtime-async-std-native-tls", "sqlite" ] }
-async-std = { version = "1", features = [ "attributes" ] } 
+async-std = { version = "1", features = [ "attributes" ] }
+tabwriter = { version = "1.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ toml = { version = "0.5.9" }
 sqlx = { version = "0.6", features = [  "runtime-async-std-native-tls", "sqlite" ] }
 async-std = { version = "1", features = [ "attributes" ] }
 tabwriter = { version = "1.2.1" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/doc/get.md
+++ b/doc/get.md
@@ -1,0 +1,45 @@
+# `get`: Get Rows
+
+You can read rows from tables using `nanobot get`:
+
+```console tesh-session="test"
+$ nanobot init
+Initialized a Nanobot project
+$ nanobot get table
+table     path                     description                         type
+table     src/schema/table.tsv     All of the tables in this project.  table
+column    src/schema/column.tsv    Columns for all of the tables.      column
+datatype  src/schema/datatype.tsv  Datatypes for all of the columns    datatype
+```
+
+This reads the first 100 rows of the 'table' table
+and prints them to STDOUT with "elastic tabstops"
+for human-readability.
+
+For machine-readability use `--format json`.
+The output is designed to match [PostgREST](https://postgrest.org).
+Piping the output through `jq` makes it easier to read:
+
+```console
+$ nanobot get table --format json | jq
+[
+  {
+    "table": "table",
+    "path": "src/schema/table.tsv",
+    "description": "All of the tables in this project.",
+    "type": "table"
+  },
+  {
+    "table": "column",
+    "path": "src/schema/column.tsv",
+    "description": "Columns for all of the tables.",
+    "type": "column"
+  },
+  {
+    "table": "datatype",
+    "path": "src/schema/datatype.tsv",
+    "description": "Datatypes for all of the columns",
+    "type": "datatype"
+  }
+]
+```

--- a/doc/get.md
+++ b/doc/get.md
@@ -6,10 +6,10 @@ You can read rows from tables using `nanobot get`:
 $ nanobot init
 Initialized a Nanobot project
 $ nanobot get table
-row_number  table     path                     description                         type
-1           table     src/schema/table.tsv     All of the tables in this project.  table
-2           column    src/schema/column.tsv    Columns for all of the tables.      column
-3           datatype  src/schema/datatype.tsv  Datatypes for all of the columns    datatype
+table     path                     description                         type
+table     src/schema/table.tsv     All of the tables in this project.  table
+column    src/schema/column.tsv    Columns for all of the tables.      column
+datatype  src/schema/datatype.tsv  Datatypes for all of the columns    datatype
 ```
 
 This reads the first 100 rows of the 'table' table
@@ -24,21 +24,18 @@ Piping the output through `jq` makes it easier to read:
 $ nanobot get table --format json | jq
 [
   {
-    "row_number": 1,
     "table": "table",
     "path": "src/schema/table.tsv",
     "description": "All of the tables in this project.",
     "type": "table"
   },
   {
-    "row_number": 2,
     "table": "column",
     "path": "src/schema/column.tsv",
     "description": "Columns for all of the tables.",
     "type": "column"
   },
   {
-    "row_number": 3,
     "table": "datatype",
     "path": "src/schema/datatype.tsv",
     "description": "Datatypes for all of the columns",

--- a/doc/get.md
+++ b/doc/get.md
@@ -6,10 +6,10 @@ You can read rows from tables using `nanobot get`:
 $ nanobot init
 Initialized a Nanobot project
 $ nanobot get table
-table     path                     description                         type
-table     src/schema/table.tsv     All of the tables in this project.  table
-column    src/schema/column.tsv    Columns for all of the tables.      column
-datatype  src/schema/datatype.tsv  Datatypes for all of the columns    datatype
+row_number  table     path                     description                         type
+1           table     src/schema/table.tsv     All of the tables in this project.  table
+2           column    src/schema/column.tsv    Columns for all of the tables.      column
+3           datatype  src/schema/datatype.tsv  Datatypes for all of the columns    datatype
 ```
 
 This reads the first 100 rows of the 'table' table
@@ -24,18 +24,21 @@ Piping the output through `jq` makes it easier to read:
 $ nanobot get table --format json | jq
 [
   {
+    "row_number": 1,
     "table": "table",
     "path": "src/schema/table.tsv",
     "description": "All of the tables in this project.",
     "type": "table"
   },
   {
+    "row_number": 2,
     "table": "column",
     "path": "src/schema/column.tsv",
     "description": "Columns for all of the tables.",
     "type": "column"
   },
   {
+    "row_number": 3,
     "table": "datatype",
     "path": "src/schema/datatype.tsv",
     "description": "Datatypes for all of the columns",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn init() -> Result<String, String> {
         Err(String::from("nanobot.toml file already exists."))
     } else {
         fs::copy("src/resources/default_config.toml", "nanobot.toml").unwrap();
-        Ok(String::from("Hello world"))
+        Ok(String::from("Initialized a Nanobot project"))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,13 @@ fn init() -> Result<String, String> {
     if Path::new("nanobot.toml").exists() {
         Err(String::from("nanobot.toml file already exists."))
     } else {
-        fs::copy("src/resources/default_config.toml", "nanobot.toml").unwrap();
+        let toml = r#"[tool]
+name = "nanobot"
+version = "0.1.0"
+edition = "2021"
+"#;
+        fs::write("nanobot.toml", toml).expect("Unable to write file");
+
         Ok(String::from("Initialized a Nanobot project"))
     }
 }
@@ -62,12 +68,11 @@ async fn get_table_from_database(database: &str, table: &str) -> Result<String, 
         _ => panic!("Unsupported table"),
     };
 
-    let query_string = format!("SELECT * FROM '{}'", &table_checked); //TODO: change this to 'table'
+    let query_string = format!("SELECT * FROM '{}'", &table_checked);
     let rows: Vec<SqliteRow> = sqlx::query(&query_string).fetch_all(&pool).await.unwrap();
 
-    let str_result = format_table_stdout(&rows);
-
-    Ok(str_result)
+    let result = format_table_stdout(&rows);
+    Ok(result)
 }
 
 /// Merge two toml::Values.


### PR DESCRIPTION
Closes #15.

The `tesh` test uses `nanobot init`. However, this command is not implemented on this branch. In particular, the creation of `.nanobot.db` is missing (see #13).