### PR TITLE
Fix missing table.edit_view

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub asset_path: Option<String>,
     pub template_path: Option<String>,
     pub actions: IndexMap<String, ActionConfig>,
+    pub table: Vec<SerdeMap>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
@@ -353,6 +354,7 @@ impl Config {
                 }
             },
             actions: user.actions.unwrap_or_default(),
+            table: vec![],
         };
 
         Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use crate::{config::Config, error::NanobotError, serve::build_app};
+use crate::{config::Config, error::NanobotError, serve::build_app, sql::get_table_from_pool};
 use axum_test_helper::{TestClient, TestResponse};
 use clap::{arg, command, value_parser, Command};
+use ontodev_sqlrest::Select;
 use ontodev_valve::valve::Valve;
 use std::path::Path;
 use std::sync::Arc;
@@ -158,6 +159,11 @@ async fn build_valve(config: &mut Config) -> Result<(), NanobotError> {
     (config.valve, config.pool) = {
         let valve = Valve::build(&config.valve_path, &config.connection).await?;
         let pool = valve.pool.clone();
+        let table_select = Select::new("\"table\"");
+        config.table = get_table_from_pool(&pool, &table_select)
+            .await
+            .unwrap()
+            .clone();
         (Some(valve), Some(pool))
     };
     Ok(())


### PR DESCRIPTION
Switching to VALVE structs had the unintended consequence of hiding non-standard columns of the "table" table from the templates, which meant that templates could not access the `table.edit_view` field. This PR restores that functionality, by fetching and caching the "table" table when Nanobot is started.
