### PR TITLE
Improve server, rename --connection option

### DIFF
--- a/examples/penguins/nanobot.toml
+++ b/examples/penguins/nanobot.toml
@@ -1,8 +1,0 @@
-[nanobot]
-config_version = 0
-
-[logging]
-level = "DEBUG"
-
-[templates]
-path = "src/resources/"


### PR DESCRIPTION
- add `nanobot serve --connection URL` option
- add special handling of `nanobot serve --connection :memory:` option: also load VALVE tables
- exit gracefully from server on Ctrl-C
- always print server address